### PR TITLE
Fixed code blocks not wrapping correctly, breaking layout in mobile display.

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -16,11 +16,11 @@ const post = Astro.props;
 const { headings, Content } = await post.render();
 ---
 <BlogPost {...post.data}>
-    <div style="display: flex; flex-direction: row; gap: 1rem">
+    <div class="blog-container">
         <div class="blog-toc">
             <TableOfContent headings={headings} />
         </div>
-        <div style="flex: 8">
+        <div class="blog-content">
             <Content />
         </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,9 +127,21 @@ hr {
 	border-top: 1px solid rgb(var(--gray-light));
 }
 
+.blog-container {
+    display: flex; 
+    flex-direction: row; 
+    
+    gap: 1rem;
+}
 .blog-toc {
     flex: 2; 
     margin-right: 1rem
+}
+.blog-content {
+    flex: 8;
+}
+.blog-content pre {
+    text-wrap: wrap;
 }
 @media (max-width: 720px) {
 	body {


### PR DESCRIPTION
The `<pre>` tags by default do not wrap text as they preserve whitespace, line breaks, etc..

This breaks the layout on mobile as it stretches out the page if the code blocks are too wide.