### PR TITLE
Change the deployment workflow trigger to push event on master branch.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy
 
-on: [workflow_dispatch]
+on: 
+  push:
+    branches:
+      - master
 
 permissions:
   id-token: write


### PR DESCRIPTION
I had this workflow set to `workflow_dispatch` which required manual triggering of deployment. I realized after each merge I was just manually triggering it every time so I decided to just make it automated on each merge into master.