### PR TITLE
Fix timezone for session hijacking post.

### DIFF
--- a/src/content/blog/session-hijacking.md
+++ b/src/content/blog/session-hijacking.md
@@ -1,5 +1,5 @@
 ---
-pubDate: 2024-26-11T10:09:23+11:00
+pubDate: 2024-12-03T18:00:38.2581161+11:00
 
 author: lewpar
 contributors:


### PR DESCRIPTION
This post was showing 2 years in the future due to invalid date time. I am not a time traveler.